### PR TITLE
Fix Dockerfile: update OpenJDK base image to a valid tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mvn clean install -DskipTests=true
 #--------------------------------------
 
 # Import small size java image
-FROM openjdk:17-alpine as deployer
+FROM openjdk:17-jdk-alpin as deployer
 
 # Copy build from stage 1 (builder)
 COPY --from=builder /app/target/*.jar /app/target/bankapp.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mvn clean install -DskipTests=true
 #--------------------------------------
 
 # Import small size java image
-FROM openjdk:17-jdk-alpin as deployer
+FROM openjdk:17-jdk-alpine as deployer
 
 # Copy build from stage 1 (builder)
 COPY --from=builder /app/target/*.jar /app/target/bankapp.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,14 @@
 #----------------------------------
 
 # Import docker image with maven installed
-FROM maven:3.8.3-openjdk-17 as builder 
-
+# FROM maven:3.8.3-openjdk-17 as builder 
+# Import docker image with Maven and JDK 17 (from Eclipse Temurin)
+FROM maven:3.8.3-eclipse-temurin-17 as builder
 # Set working directory
 WORKDIR /app
 
 # Copy source code from local to container
-COPY . /app
+COPY . /appFROM openjdk:17-jdk-alpine as deployer
 
 # Build application and skip test cases
 RUN mvn clean install -DskipTests=true
@@ -19,7 +20,10 @@ RUN mvn clean install -DskipTests=true
 #--------------------------------------
 
 # Import small size java image
-FROM openjdk:17-jdk-alpine as deployer
+# FROM openjdk:17-alpine as deployer
+# Use eclipse-temurin:17-jdk-alpine for runtime
+FROM eclipse-temurin:17-jdk-alpine as deployer
+
 
 # Copy build from stage 1 (builder)
 COPY --from=builder /app/target/*.jar /app/target/bankapp.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM maven:3.8.3-eclipse-temurin-17 as builder
 WORKDIR /app
 
 # Copy source code from local to container
-COPY . /appFROM openjdk:17-jdk-alpine as deployer
+COPY . /app
 
 # Build application and skip test cases
 RUN mvn clean install -DskipTests=true


### PR DESCRIPTION
@Amitabh-DevOps 

I noticed that the Dockerfile was using the `openjdk:17-alpine` tag, which seems to be unavailable, causing build issues. I've replaced it with the `eclipse-temurin:17-jdk-alpine` image, which is a stable and well-supported JDK 17 base image from the Eclipse Temurin project. This change should resolve the issue and improve build consistency.

### Changes:
- Updated `FROM openjdk:17-alpine` to `FROM eclipse-temurin:17-jdk-alpine`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker base images for both build and deployment stages to Eclipse Temurin Java 17, improving runtime compatibility and security.
* **Documentation**
  * Added runtime-related comments in the Dockerfile to clarify image choices and runtime expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->